### PR TITLE
Use compile env

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a
 Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 1.0.1 - 2022-09-22
+
+### Fixed
+- Fixed descouraged use warning
+
 ## 1.0.0
 
 This release marks stability in the API and does not present a functional change

--- a/lib/beeline/appsignal.ex
+++ b/lib/beeline/appsignal.ex
@@ -36,7 +36,7 @@ defmodule Beeline.Appsignal do
     to which the delta should be published
   """
 
-  @appsignal Application.get_env(:beeline_appsignal, :appsignal, Appsignal)
+  @appsignal Application.compile_env(:beeline_appsignal, :appsignal, Appsignal)
 
   use Task
 


### PR DESCRIPTION
Fixes discouraged usage warning:

```
warning: Application.get_env/3 is discouraged in the module body, use Application.compile_env/3 instead
  lib/beeline/appsignal.ex:39: Beeline.Appsignal
```